### PR TITLE
Update template and Spotify example with META-ID API updates

### DIFF
--- a/example/spotify/index.js
+++ b/example/spotify/index.js
@@ -5,6 +5,7 @@ const {
   fromRpcSig,
   pubToAddress,
   sha3,
+  toBuffer,
   toChecksumAddress,
   toRpcSig
 } = require('ethereumjs-util')
@@ -24,7 +25,6 @@ if (process.env.NODE_ENV !== 'production') {
 module.exports = cors(async (req, res) => {
   // META Claims Service config
   const metaClaimsService = {
-    // address: process.env.ETHEREUM_ADDRESS,
     id: process.env.META_ID,
     privateKey: process.env.PRIVATE_KEY,
     property: process.env.CLAIM_PROPERTY,
@@ -73,8 +73,13 @@ module.exports = cors(async (req, res) => {
   // set the claim value being verified
   const verifiedClaimValue = claimMessage
 
-  // generate verified claim buffer from verified claim value
-  const verifiedClaimBuffer = sha3(verifiedClaimValue)
+  // generate verified claim buffer
+  const verifiedClaimBuffer = sha3(Buffer.concat([
+    toBuffer(metaClaimsService.id),
+    toBuffer(subject),
+    toBuffer(metaClaimsService.property),
+    toBuffer(verifiedClaimValue),
+  ]))
 
   // generate ECDSA signature of verified claim buffer using the MCS private key
   const verifiedClaimSignatureObject = ecsign(

--- a/example/spotify/test/fixtures/claim.json
+++ b/example/spotify/test/fixtures/claim.json
@@ -1,7 +1,8 @@
 {
-  "address": "0xc4300acba32f5631ec4e45b3d62bd31f947a27e3",
+  "address": "0xadE4772179087732696bE0Bc947412C6c5098Dd6",
   "claimHash": "0xe6f4391f95da3fd64c4a0f4099e22341df3e55f34a549c361bc9c4bff819af1d",
-  "claimValue": "lukehedger",
-  "oAuthToken": "BQBg_vI-kIrepSAPajGaPdtrROM_b7ZJRo4bY0n_3zPtIxE5DlPtM6Jwa9UIhnQoU8xmU5gUBA4BRJEnxWVcemjiYfSu5IMZnzukuy2HEqxCj-vVZMtmZYPibnhhLq9AQTT03gFnBNXVmbRv1Uvt902CSaOafGc",
-  "signature": "0x2a853be21bebdb89346b361e144fc12eff88b43923850c2e1bc3803dc9c9c7e75c6028692ec5dca710f3f6a99ec4059aa998fd44b6c34153dedbf7fa9196d2c100"
+  "claimMessage": "lukehedger",
+  "oAuthToken": "BQAABjf3V00wr6CVC5VHqjRf-Q8hjzvZozx-ffdUTHd_GOtK1c-gtTQj1s4VgjovIkNWRSqUKZiJ4JlKoeCQdwkN4njgdaP1zydomHMVCs9GtK4R_pIID-PMFKchIMAvEBvFkqpfyfsZBkn88zcMwiYx0_bA4dI",
+  "signature": "0x3507bf33dc75212a7da5e43ab3d92b74bc698732e381b01075bd602d65c29adc56fb3aebe1c670e20df7048faaa32595b82c95abb0a72e4077a3eb8e9141c71101",
+  "subject": "0xe864f1c2c17d143cfbc1ae68f2977e0068a2b13342f12834a4184c8a31d7b84f"
 }

--- a/example/spotify/test/fixtures/verified-claim.json
+++ b/example/spotify/test/fixtures/verified-claim.json
@@ -1,7 +1,7 @@
 {
   "claim": "lukehedger",
-  "issuer": "0xF540Ecfd7516c73596F27309bC7A28a56f2ee040",
-  "property": "spotifyId",
-  "signature": "0xe133d208d2c37cfeade9ac138cc87c27695992c2c6f6c20b9ac98859fe0767247f330c758a5b06b8f4020fc43824cb2e35c46f5393335e227c3974c68cef76ab01",
-  "subject": "0xc4300acba32f5631ec4e45b3d62bd31f947a27e3"
+  "issuer": "0x3ec8f4fbab9e1d1ae2de977542d7c0200474b0599a4d902314a7ed2b1940478f",
+  "property": "spotifyid",
+  "signature": "0x1c7f5e080aeaba8b73470d8bdf0bb912d7f79afa90a3ce041e7ffc0617d03d6f7a7615e322ff0bcf5620dbdcb456b413573ac21507c73c74e533290756eb040100",
+  "subject": "0xe864f1c2c17d143cfbc1ae68f2977e0068a2b13342f12834a4184c8a31d7b84f"
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const {
   fromRpcSig,
   pubToAddress,
   sha3,
+  toBuffer,
   toChecksumAddress,
   toRpcSig
 } = require('ethereumjs-util')
@@ -23,7 +24,6 @@ if (process.env.NODE_ENV !== 'production') {
 module.exports = cors(async (req, res) => {
   // META Claims Service config
   const metaClaimsService = {
-    // address: process.env.ETHEREUM_ADDRESS,
     id: process.env.META_ID,
     privateKey: process.env.PRIVATE_KEY,
     property: process.env.CLAIM_PROPERTY,
@@ -72,8 +72,13 @@ module.exports = cors(async (req, res) => {
   // set the claim value being verified
   const verifiedClaimValue = claimMessage
 
-  // generate verified claim buffer from verified claim value
-  const verifiedClaimBuffer = sha3(verifiedClaimValue)
+  // generate verified claim buffer
+  const verifiedClaimBuffer = sha3(Buffer.concat([
+    toBuffer(metaClaimsService.id),
+    toBuffer(subject),
+    toBuffer(metaClaimsService.property),
+    toBuffer(verifiedClaimValue),
+  ]))
 
   // generate ECDSA signature of verified claim buffer using the MCS private key
   const verifiedClaimSignatureObject = ecsign(

--- a/test/fixtures/claim.json
+++ b/test/fixtures/claim.json
@@ -1,6 +1,7 @@
 {
-  "address": "0xc4300acba32f5631ec4e45b3d62bd31f947a27e3",
-  "claimHash": "0x0144b03a9f213f42c974de61cf2bc229ea0e45254ceebf5781c95f16cbf14f39",
-  "claimValue": "meta",
-  "signature": "0xe8376cb321a3046ad249e0409f41568f12b4dfefee9f14d77cda0e1c3510f9fc6df681bcbbfbdc8d1f9b6032a475fc2628b9ebc7f4ce74f4b05312a32fa12d8d01"
+  "address": "0xadE4772179087732696bE0Bc947412C6c5098Dd6",
+  "claimHash": "0xe864f1c2c17d143cfbc1ae68f2977e0068a2b13342f12834a4184c8a31d7b84f",
+  "claimMessage": "ray.id.meta",
+  "signature": "0x156e0666d92c5f382825f961c6a380398674b0a3aba30f994f1b26ab3d330c653d03db0b0985dda16cbce0f7deffaebebd8259516028bf099ef9ec25f44a7a1100",
+  "subject": "0xe864f1c2c17d143cfbc1ae68f2977e0068a2b13342f12834a4184c8a31d7b84f"
 }

--- a/test/fixtures/verified-claim.json
+++ b/test/fixtures/verified-claim.json
@@ -1,7 +1,7 @@
 {
-  "claim": "meta",
-  "issuer": "0xF540Ecfd7516c73596F27309bC7A28a56f2ee040",
-  "property": "metaId",
-  "signature": "0xe4eb498647da10e1dae15d75b3365800dc08174afd0f25be437b61ea39d2bf9857844da950b0f9fcefe0db62591a03ec6b5930c473a0db52c3c9f9adbf8fcfe301",
-  "subject": "0xc4300acba32f5631ec4e45b3d62bd31f947a27e3"
+  "claim": "ray.id.meta",
+  "issuer": "0x2013ce5cacbfb860251db4c55f0ed4d70e89c6c6700a5fd7a38fe45afa12ec92",
+  "property": "metaid",
+  "signature": "0xf87b4075132ce1cbc61ea2059c1b134e70269c2b7445f2fd8b1a56ebe8c7fccd7ca219d8ca4eb0193ef36046175cf84318e413415e1c9f16f55aab28df40048301",
+  "subject": "0xe864f1c2c17d143cfbc1ae68f2977e0068a2b13342f12834a4184c8a31d7b84f"
 }


### PR DESCRIPTION
Closes #6 

- Sign 'Claim ID' value
```
claimId = sha3(issuerId, subjectId, claimProperty, claimValue)
```
- Use 'Identity ID' value to identify issuers and subjects (as opposed to Ethereum address)